### PR TITLE
Add port type CSS class

### DIFF
--- a/packages/baklavajs-plugin-interface-types/src/index.ts
+++ b/packages/baklavajs-plugin-interface-types/src/index.ts
@@ -92,6 +92,7 @@ export class InterfaceTypePlugin implements IPlugin {
                 const color = this.types.get(intf.data.type)!.color;
                 const res = intf.$el.getElementsByClassName("__port");
                 Array.from(res).forEach((el) => {
+                    (el as HTMLElement).className += " __port-" + intf.data.type;
                     (el as HTMLElement).style.backgroundColor = color;
                 });
             }


### PR DESCRIPTION
Adds `__port-<interface type>` to ports for styling purposes.